### PR TITLE
Gnome 41, 42 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "DuckDuckGo Search Provider",
-    "shell-version": ["3.36", "3.38", "40.0"],
+    "shell-version": ["3.36", "3.38", "40.0", "41.0", "42.0"],
     "uuid": "gnome-shell-duckduckgo-search-provider@keithcirkel.co.uk",
     "settings-schema": "org.gnome.shell.extensions.duckduckgo-search-provider",
     "description": "Add DuckDuckGo search suggestions to Gnome Shell Search",


### PR DESCRIPTION
I have tested this extension in gnome 42 and just updating the metadata will be fine to keep the extension on going.